### PR TITLE
FEATURE | Provides order comment to Wallee

### DIFF
--- a/custom/plugins/WalleePayment/Components/Transaction.php
+++ b/custom/plugins/WalleePayment/Components/Transaction.php
@@ -630,6 +630,10 @@ class Transaction extends AbstractService
         
         $pluginConfig = $this->configReader->getByPluginName('WalleePayment', $order->getShop());
 
+        if($pluginConfig['provideOrderComment']){
+            $transaction->setMetaData($this->getOrderComment($order));
+        }
+
         if ($transaction instanceof \Wallee\Sdk\Model\TransactionCreate) {
             $transaction->setSpaceViewId($pluginConfig['spaceViewId']);
             $transaction->setAutoConfirmationEnabled(false);
@@ -937,5 +941,24 @@ class Transaction extends AbstractService
             $this->modelManager = $this->modelManager->create($this->modelManager->getConnection(), $this->modelManager->getConfiguration());
         }
         return $this->modelManager;
+    }
+
+    /**
+     * Add customer comment to wallee transaction as meta_data.
+     * @param \Shopware\Models\Order\Order $order
+     * @return array (key,value) - Order comment (max limit 512 chars) if exist, otherwise empty string.
+     */
+    private function getOrderComment(Order $order) {
+        $orderComment = '';
+
+        if ($orderComment = $order->getCustomerComment()){
+            $orderComment = substr($order->getCustomerComment(),0,512);
+        }
+
+        $metaData = [
+            'orderComment' => $orderComment,
+        ];
+
+        return $metaData;
     }
 }

--- a/custom/plugins/WalleePayment/Resources/config.xml
+++ b/custom/plugins/WalleePayment/Resources/config.xml
@@ -126,6 +126,14 @@
 			<value>0</value>
         </element>
         <element type="boolean" scope="shop">
+            <name>provideOrderComment</name>
+            <label lang="de">Bestellkommentar übermitteln</label>
+            <label lang="en">Provide order comment</label>
+            <value>0</value>
+            <description lang="de">Dokumenttemplate invoice.twig muss mit dem Baustein {{transaction.metaData.orderComment}} ergänzt werden.</description>
+            <description lang="en">Block {{transaction.metaData.orderComment}} must be added to documenttemplate invocie.twig</description>
+        </element>
+        <element type="boolean" scope="shop">
 			<name>enforceLineItemConsistency</name>
 			<label lang="de">Konsistenz sicherstellen</label>
 			<label lang="en">Enforce Consistency</label>

--- a/custom/plugins/WalleePayment/plugin.xml
+++ b/custom/plugins/WalleePayment/plugin.xml
@@ -14,7 +14,7 @@
     <label lang="de">wallee Payment</label>
     <label lang="en">wallee Payment</label>
 
-    <version>1.1.12</version>
+    <version>1.1.13</version>
     <copyright>(c) by wallee AG</copyright>
     <license>Apache-2.0</license>
     <link>https://www.wallee.com</link>
@@ -22,6 +22,10 @@
 
     <description lang="de">wallee-Integration für Shopware 5</description>
     <description lang="en">wallee Integration for Shopware 5</description>
+    <changelog version="1.1.13">
+        <changes lang="en">Provides order comment</changes>
+        <changes lang="de">Übermittelt Bestellkommentar</changes>
+    </changelog>
     <changelog version="1.1.10">
         <changes lang="en">Add command to services.xml</changes>
         <changes lang="de">Befehl zu services.xml hinzufügen</changes>


### PR DESCRIPTION
**1. Why is this change necessary?**
Many customers add important information inside the notice textarea during the checkout process. Which sometimes can lead to manual invoice adjustment if those information were missed on the invoice.

**2. What does this change do, exactly?**
It adds new plugin configuration field to enable/disable (default) sending the order comment which is placed by the client, to Wallee as transaction metadata. And of course sets the value inside the "assembleTransactionData" method.

**3. Which documentation changes (if any) need to be made because of this PR?**
Maybe it is a good idea to replace the screenshot in the provided documentation.

**4. Checklist**

- [x] Code was tested inside live environment before PR
- [x] Coding guidelines followed by best knowledge